### PR TITLE
Fix compute sh args

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ npm run serve
 to have a live-updating server.
 
 ## Browser compatibility
-The official compatiblity table of WebGPU can be found [here](https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API#browser_compatibility). In practice, I have only succeeded in running it on MacOS and Ubuntu.
+The official compatiblity table of WebGPU can be found [here](https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API#browser_compatibility). In practice, the following are known to work:
 
 **MacOS**: works with recent (version 115+) Chrome/Chromium browsers.
+
+**Windows**: works with Edge 116+, most likely with Chrome/Chromium as well (it's the same thing but I was not able to test).
 
 **Ubuntu**: works with Chrome dev version and custom flags. The steps are as follows:
 1. Download and install [Chrome dev](https://www.google.com/chrome/dev/).
 2. Launch from command line with extra flags: `google-chrome-unstable --enable-features=Vulkan,UseSkiaRenderer`.
 3. Go to `chrome://flags/#enable-unsafe-webgpu` and enable webgpu. Restart the browser for the change to take effect, make sure to use the flags from the previous step as well.
 4. The Gaussian viewer should work.
-
-**Windows**: recent Chrome is supposed to work (per implementation status) but in practice the renders are completely nonsensical. See [this tracking issue](https://github.com/cvlab-epfl/gaussian-splatting-web/issues/16).
 
 **Firefox**: the nightly channel is supposed to support webGPU experimentally but in practice it fails on parsing my shaders across MacOS/Ubuntu.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gaussian-splatting-web",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A webGPU renderer for Gaussian splatting NeRFs",
   "main": "index.js",
   "scripts": {

--- a/src/shaders.ts
+++ b/src/shaders.ts
@@ -302,7 +302,7 @@ fn vs_points(@builtin(vertex_index) vertex_index: u32) -> PointOutput {
     var projPosition = uniforms.projMatrix * vec4<f32>(point.position, 1.0);
     projPosition = projPosition / projPosition.w;
     output.position = vec4<f32>(projPosition.xy + 2 * radius_ndc * quadOffset, projPosition.zw);
-    output.color = compute_color_from_sh(uniforms.camera_position, point.sh);
+    output.color = compute_color_from_sh(point.position, point.sh);
     output.uv = radius_px * quadOffset;
 
     return output;

--- a/src/shaders.ts
+++ b/src/shaders.ts
@@ -45,20 +45,15 @@ const shDeg3Code = `
             SH_C2[3] * xz * sh[7] +
             SH_C2[4] * (xx - yy) * sh[8];
         
-        // We disable the 3rd degree for now because of a bug causing the entire render
-        // to be black. This appears to be a webGPU issue. If uncomment SH_C3[0...3] it works,
-        // if you uncomment SH_C3[4...6] it works, if you uncomment the whole and divide by 10
-        // it's black.
-
         // if (sh_degree > 2) {
-        //result = result +
-        //    SH_C3[0] * y * (3. * xx - yy) * sh[9] +
-        //    SH_C3[1] * xy * z * sh[10] +
-        //    SH_C3[2] * y * (4. * zz - xx - yy) * sh[11] +
-        //    SH_C3[3] * z * (2. * zz - 3. * xx - 3. * yy) * sh[12] +
-        //    SH_C3[4] * x * (4. * zz - xx - yy) * sh[13] +
-        //    SH_C3[5] * z * (xx - yy) * sh[14] +
-        //    SH_C3[6] * x * (xx - 3. * yy) * sh[15];
+        result = result +
+            SH_C3[0] * y * (3. * xx - yy) * sh[9] +
+            SH_C3[1] * xy * z * sh[10] +
+            SH_C3[2] * y * (4. * zz - xx - yy) * sh[11] +
+            SH_C3[3] * z * (2. * zz - 3. * xx - 3. * yy) * sh[12] +
+            SH_C3[4] * x * (4. * zz - xx - yy) * sh[13] +
+            SH_C3[5] * z * (xx - yy) * sh[14] +
+            SH_C3[6] * x * (xx - 3. * yy) * sh[15];
 
         // unconditional
         result = result + 0.5;


### PR DESCRIPTION
#17 found a bug in passing camera position argument to compute_color_from_sh. Not only was the formula incorrect, it also caused division by zero leading to #2 and #16.